### PR TITLE
Extend validation code

### DIFF
--- a/src/fit_embrapa_validation_hmm.R
+++ b/src/fit_embrapa_validation_hmm.R
@@ -12,7 +12,7 @@ library(stringr)
 
 set.seed(789)
 
-opt_list <- list(make_option("--n_bootstrap_samples", default=100, type=("integer")),
+opt_list <- list(make_option("--n_bootstrap_samples", default=200, type=("integer")),
                  make_option("--panel_length", default="short"),
                  make_option("--classifier_training_fraction", default=0.15, type="double"),
                  make_option("--classifier_pasture_fraction", default=0.6, type="double",
@@ -484,7 +484,7 @@ p <- ggplot(boots_summary_accuracy,
     geom_errorbarh(height=0) +
     scale_x_continuous('Classification Accuracy') +
     theme(axis.title.y=element_blank())
-ggsave("embrapa_bootstrap_classification_accuracy_confidence_intervals.png", width=10, height=8)
+ggsave("embrapa_bootstrap_classification_accuracy_confidence_intervals.png", width=8, height=6)
 
 p <- ggplot(boots_summary_P_errors,
             aes(x = mean_estimated_value, y = estimator_factor, xmin = lb, xmax = ub)) +
@@ -494,7 +494,7 @@ p <- ggplot(boots_summary_P_errors,
     theme(axis.title.y=element_blank()) +
     facet_wrap(~ variable, scales='free_x') +
     geom_vline(xintercept = 0, linetype=2)
-ggsave("embrapa_bootstrap_transition_probability_time_homogeneous_errors_confidence_intervals.png", p, width=10, height=8)
+ggsave("embrapa_bootstrap_transition_probability_time_homogeneous_errors_confidence_intervals.png", p, width=8, height=6)
 
 p <- ggplot(boots_summary_P,
             aes(x = mean_estimated_value, y = estimator_factor, xmin = lb, xmax = ub)) +
@@ -503,7 +503,7 @@ p <- ggplot(boots_summary_P,
     scale_x_continuous('Transition Rate') +
     theme(axis.title.y=element_blank()) +
     facet_wrap(~ variable, scales='free_x')
-ggsave("embrapa_bootstrap_transition_probability_time_homogeneous_confidence_intervals.png", p, width=10, height=8)
+ggsave("embrapa_bootstrap_transition_probability_time_homogeneous_confidence_intervals.png", p, width=8, height=6)
 
 p <- ggplot(boots_summary_P_time_varying_errors,
             aes(x = mean_estimated_value, y = estimator_factor, xmin = lb, xmax = ub)) +
@@ -513,7 +513,7 @@ p <- ggplot(boots_summary_P_time_varying_errors,
     theme(axis.title.y=element_blank()) +
     facet_grid(transition_year ~ variable, scales='free') +
     geom_vline(xintercept = 0, linetype=2)
-ggsave("embrapa_bootstrap_transition_probability_time_varying_errors_confidence_intervals.png", p, width=10, height=12)
+ggsave("embrapa_bootstrap_transition_probability_time_varying_errors_confidence_intervals.png", p, width=8, height=10)
 
 p <- ggplot(boots_summary_P_time_varying,
             aes(x = mean_estimated_value, y = estimator_factor, xmin = lb, xmax = ub)) +
@@ -522,7 +522,7 @@ p <- ggplot(boots_summary_P_time_varying,
     scale_x_continuous('Transition Rate') +
     theme(axis.title.y=element_blank()) +
     facet_grid(transition_year ~ variable, scales='free')
-ggsave("embrapa_bootstrap_transition_probability_time_varying_confidence_intervals.png", p, width=10, height=12)
+ggsave("embrapa_bootstrap_transition_probability_time_varying_confidence_intervals.png", p, width=8, height=10)
 
 boots_summary_pr_y <- subset(boots_summary, variable %in% c("Pr[Y = pasture | S = pasture]", "Pr[Y = crops | S = crops]"))
 
@@ -533,7 +533,7 @@ p <- ggplot(boots_summary_pr_y,
     scale_x_continuous('Pr[Y | S]') +
     theme(axis.title.y=element_blank()) +
     facet_grid(estimator_type ~ variable, scales='free_x')
-ggsave("embrapa_bootstrap_pr_y_given_s_confidence_intervals.png", p, width=10, height=8)
+ggsave("embrapa_bootstrap_pr_y_given_s_confidence_intervals.png", p, width=8, height=6)
 
 message("GBM test set confusion matrix:")
 print(gbm_test_confusion)

--- a/src/fit_embrapa_validation_hmm.R
+++ b/src/fit_embrapa_validation_hmm.R
@@ -387,18 +387,21 @@ run_bootstrap <- function() {
                                                                    md_params_hat_time_varying$pr_y[2, 2],
                                                                    prediction_confusion_matrix[2, 2]))
 
-    ## TODO Add MD Pr[Y | S]
     df_pr_y_crops <- data.frame("variable"="Pr[Y = crops | S = crops]",
                                 "transition_year"="",
                                 "estimator_type"="Time Homogeneous",
-                                "estimator"=c("EM", "Ground Truth"),
-                                "estimated_value"=c(hmm_params_hat$pr_y[1, 1], prediction_confusion_matrix[1, 1]))
+                                "estimator"=c("EM", "MD", "Ground Truth"),
+                                "estimated_value"=c(hmm_params_hat$pr_y[1, 1],
+                                                    md_params_hat$pr_y[1, 1],
+                                                    prediction_confusion_matrix[1, 1]))
 
     df_pr_y_pasture <- data.frame("variable"="Pr[Y = pasture | S = pasture]",
                                   "transition_year"="",
                                   "estimator_type"="Time Homogeneous",
-                                  "estimator"=c("EM", "Ground Truth"),
-                                  "estimated_value"=c(hmm_params_hat$pr_y[2, 2], prediction_confusion_matrix[2, 2]))
+                                  "estimator"=c("EM", "MD", "Ground Truth"),
+                                  "estimated_value"=c(hmm_params_hat$pr_y[2, 2],
+                                                      md_params_hat$pr_y[2, 2],
+                                                      prediction_confusion_matrix[2, 2]))
 
     return(rbind(df_pr_crops_pasture_errors,
                  df_pr_crops_pasture,

--- a/src/fit_embrapa_validation_hmm.R
+++ b/src/fit_embrapa_validation_hmm.R
@@ -253,6 +253,7 @@ run_bootstrap <- function() {
     estimates_time_varying <- get_hmm_and_minimum_distance_estimates_random_initialization(params0, panel_boot)
 
     hmm_params_hat_time_varying <- estimates_time_varying$em_params_hat_best_likelihood
+    md_params_hat_time_varying <- estimates_time_varying$min_dist_params_hat_best_objfn
 
     transition_years <- seq(min(dtable$year), max(dtable$year) - 1)
     pr_transition_boot_time_varying <- lapply(transition_years, function(fixed_year) {
@@ -279,31 +280,56 @@ run_bootstrap <- function() {
                                                           pr_transition_boot[2, 1]))
 
     ## TODO Lapply over years instead of repeating code for first year, second year, etc
-    df_pr_pasture_crops_time_varying1 <- data.frame("variable"=rep("Pasture to Crops First Year", 3),
+    df_pr_pasture_crops_time_varying1 <- data.frame("variable"=rep("Pasture to Crops First Year", 4),
                                                     "time_homogeneous"=FALSE,
-                                                    "estimator"=c("EM", "Frequency", "Ground Truth"),
+                                                    "estimator"=c("EM", "MD", "Frequency", "Ground Truth"),
                                                     "estimated_value"=c(hmm_params_hat_time_varying$P_list[[1]][2, 1],
+                                                                        md_params_hat_time_varying$P_list[[1]][2, 1],
                                                                         pr_transition_boot_predictions_time_varying[[1]][2, 1],
                                                                         pr_transition_boot_time_varying[[1]][2, 1]))
-    df_pr_pasture_crops_time_varying2 <- data.frame("variable"=rep("Pasture to Crops Second Year", 3),
+    df_pr_pasture_crops_time_varying2 <- data.frame("variable"=rep("Pasture to Crops Second Year", 4),
                                                     "time_homogeneous"=FALSE,
-                                                    "estimator"=c("EM", "Frequency", "Ground Truth"),
+                                                    "estimator"=c("EM", "MD", "Frequency", "Ground Truth"),
                                                     "estimated_value"=c(hmm_params_hat_time_varying$P_list[[2]][2, 1],
+                                                                        md_params_hat_time_varying$P_list[[2]][2, 1],
                                                                         pr_transition_boot_predictions_time_varying[[2]][2, 1],
                                                                         pr_transition_boot_time_varying[[2]][2, 1]))
-
-    df_pr_crops_pasture_time_varying1 <- data.frame("variable"=rep("Crops to Pasture First Year", 3),
+    df_pr_pasture_crops_time_varying3 <- data.frame("variable"=rep("Pasture to Crops Third Year", 4),
                                                     "time_homogeneous"=FALSE,
-                                                    "estimator"=c("EM", "Frequency", "Ground Truth"),
+                                                    "estimator"=c("EM", "MD", "Frequency", "Ground Truth"),
+                                                    "estimated_value"=c(hmm_params_hat_time_varying$P_list[[3]][2, 1],
+                                                                        md_params_hat_time_varying$P_list[[3]][2, 1],
+                                                                        pr_transition_boot_predictions_time_varying[[3]][2, 1],
+                                                                        pr_transition_boot_time_varying[[3]][2, 1]))
+    df_pr_pasture_crops_time_varying4 <- data.frame("variable"=rep("Pasture to Crops Fourth Year", 4),
+                                                    "time_homogeneous"=FALSE,
+                                                    "estimator"=c("EM", "MD", "Frequency", "Ground Truth"),
+                                                    "estimated_value"=c(hmm_params_hat_time_varying$P_list[[4]][2, 1],
+                                                                        md_params_hat_time_varying$P_list[[4]][2, 1],
+                                                                        pr_transition_boot_predictions_time_varying[[4]][2, 1],
+                                                                        pr_transition_boot_time_varying[[4]][2, 1]))
+
+    df_pr_crops_pasture_time_varying1 <- data.frame("variable"=rep("Crops to Pasture First Year", 4),
+                                                    "time_homogeneous"=FALSE,
+                                                    "estimator"=c("EM", "MD", "Frequency", "Ground Truth"),
                                                     "estimated_value"=c(hmm_params_hat_time_varying$P_list[[1]][2, 1],
+                                                                        md_params_hat_time_varying$P_list[[1]][2, 1],
                                                                         pr_transition_boot_predictions_time_varying[[1]][2, 1],
                                                                         pr_transition_boot_time_varying[[1]][2, 1]))
-    df_pr_crops_pasture_time_varying2 <- data.frame("variable"=rep("Crops to Pasture Second Year", 3),
+    df_pr_crops_pasture_time_varying2 <- data.frame("variable"=rep("Crops to Pasture Second Year", 4),
                                                     "time_homogeneous"=FALSE,
-                                                    "estimator"=c("EM", "Frequency", "Ground Truth"),
+                                                    "estimator"=c("EM", "MD", "Frequency", "Ground Truth"),
                                                     "estimated_value"=c(hmm_params_hat_time_varying$P_list[[2]][1, 2],
+                                                                        md_params_hat_time_varying$P_list[[2]][1, 2],
                                                                         pr_transition_boot_predictions_time_varying[[2]][1, 2],
                                                                         pr_transition_boot_time_varying[[2]][1, 2]))
+    df_pr_crops_pasture_time_varying3 <- data.frame("variable"=rep("Crops to Pasture Second Year", 4),
+                                                    "time_homogeneous"=FALSE,
+                                                    "estimator"=c("EM", "MD", "Frequency", "Ground Truth"),
+                                                    "estimated_value"=c(hmm_params_hat_time_varying$P_list[[3]][1, 2],
+                                                                        md_params_hat_time_varying$P_list[[3]][1, 2],
+                                                                        pr_transition_boot_predictions_time_varying[[3]][1, 2],
+                                                                        pr_transition_boot_time_varying[[3]][1, 2]))
 
     df_pr_y_crops <- data.frame("variable"=rep("Pr[Y = crops | S = crops]", 2),
                                 "time_homogeneous"=TRUE,
@@ -321,8 +347,11 @@ run_bootstrap <- function() {
                  df_pr_y_pasture,
                  df_pr_pasture_crops_time_varying1,
                  df_pr_pasture_crops_time_varying2,
+                 df_pr_pasture_crops_time_varying3,
+                 df_pr_pasture_crops_time_varying4,
                  df_pr_crops_pasture_time_varying1,
-                 df_pr_crops_pasture_time_varying2))
+                 df_pr_crops_pasture_time_varying2,
+                 df_pr_crops_pasture_time_varying3))
 
 }
 
@@ -336,12 +365,18 @@ boots_summary <- boots[, list("mean_estimated_value"=mean(estimated_value),
                               "sd_estimated_value"=sd(estimated_value)),
                        by=c("variable", "estimator")]
 
+## TODO Cutoff at zero for lower bound?  pmax(0, ...)  Some of the CIs for transition probabilities include negative values
 boots_summary[, lb := mean_estimated_value - 1.96 * sd_estimated_value]
 boots_summary[, ub := mean_estimated_value + 1.96 * sd_estimated_value]
 
 boots_summary_P <- subset(boots_summary, variable %in% c("Crops to Pasture", "Pasture to Crops"))
-boots_summary_P_time_varying <- subset(boots_summary, variable %in% c("Pasture to Crops First Year", "Pasture to Crops Second Year",
-                                                                      "Crops to Pasture First Year", "Crops to Pasture Second Year"))
+boots_summary_P_time_varying <- subset(boots_summary, variable %in% c("Pasture to Crops First Year",
+                                                                      "Pasture to Crops Second Year",
+                                                                      "Pasture to Crops Third Year",
+                                                                      "Pasture to Crops Fourth Year",
+                                                                      "Crops to Pasture First Year",
+                                                                      "Crops to Pasture Second Year",
+                                                                      "Crops to Pasture Third Year"))
 
 p <- ggplot(boots_summary_P,
             aes(x = mean_estimated_value, y = estimator, xmin = lb, xmax = ub)) +

--- a/src/simulation_simple.R
+++ b/src/simulation_simple.R
@@ -191,3 +191,6 @@ max(abs(c(min_dist_params2_hat_population$P_list, recursive=TRUE) - c(params0$P_
 
 ## Recover the initial distribution
 min_dist_params2_hat_population$mu - params0$mu
+
+## TODO Make sure this also works for time homogeneous MD code
+## (i.e. recover true parameters when using population values of M matrices)


### PR DESCRIPTION
Extend validation code:  run time-homogeneous MD in bootstrap (in addition to time-homogeneous EM), and also run time-varying MD and EM

Delete code for unused graphs (scatterplots of bootstrap results)

Remove option for ternary landuse set S (i.e. three possible land uses)